### PR TITLE
FIX: Players Model primary key auto generation configuration issue

### DIFF
--- a/src/main/java/com/app/playerservicejava/model/Player.java
+++ b/src/main/java/com/app/playerservicejava/model/Player.java
@@ -8,7 +8,7 @@ public class Player {
 
     @Id
     @Column(name = "PLAYERID")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.UUID)
     private String playerId;
 
     @Column(name = "BIRTHYEAR")


### PR DESCRIPTION
Players Model primary key auto generation configuration issue: [here](https://github.com/Intuit-A4A/backend-java-player-service/blob/main/src/main/java/com/app/playerservicejava/model/Player.java#L11) we expect the primary key to generated based on the DB table auto increment id.
The create table [here](https://github.com/Intuit-A4A/backend-java-player-service/blob/main/src/main/resources/schema.sql) does not make sure we add the auto increment constraint when the table is created.
In summary: GenerationType.IDENTITY errors often arise from a mismatch between the application's expectation of database-managed ID generation and the actual database configuration or persistence provider's handling of that configuration. GenerationType.UUID, by generating the ID within the application, bypasses these potential database-side issues, ensuring a non-null ID is always present before persistence.
Possible fixes, to be validated with the question creator or Java expert:

1. Update Players Model to use GenerationType.UUID and solve problem by generating the ID within the application [here](https://github.com/Intuit-A4A/backend-java-player-service/blob/main/src/main/java/com/app/playerservicejava/model/Player.java#L11). - ***THIS PR***
2. Update schema.sql to add auto increment constraint once table is created [here](https://github.com/Intuit-A4A/backend-java-player-service/blob/main/src/main/resources/schema.sql). Proposed fix to this issue here in this open PR: https://github.com/Intuit-A4A/backend-java-player-service/pull/8/files